### PR TITLE
Stop adding files icons to the watch graph

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -104,7 +104,6 @@ function addFileToAssets(filename, path, compilation) {
         const _source = _fs2.default.readFileSync(filename);
         const basename = filename.replace(`${path}/`, '');
 
-        compilation.fileDependencies.push(filename);
         compilation.assets[basename] = {
             source: () => _source,
             size: () => _size

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,7 +50,6 @@ export function addFileToAssets(filename, path, compilation) {
         const source = fs.readFileSync(filename);
         const basename = filename.replace(`${path}/`, '');
 
-        compilation.fileDependencies.push(filename);
         compilation.assets[basename] = {
             source: () => source,
             size: () => size


### PR DESCRIPTION
The consuming app should decide what gets watched instad of the plugin.

At least this is my current understanding 😄 